### PR TITLE
fix: require esmodules without default export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+coverage
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -1,4 +1,16 @@
 module.exports = function(path) {
   var obj = require(path);
-  return obj && obj.__esModule ? obj['default'] : obj;
+  return isEsModule(obj) ? (hasExportDefault(obj) ? obj['default'] : obj) : obj;
+}
+
+function isEsModule(obj) {
+  return obj && obj.__esModule;
+}
+
+function defined(obj, key) {
+  return obj[key] !== undefined && obj[key] !== null;
+}
+
+function hasExportDefault(obj) {
+  return defined(obj, 'default');
 }

--- a/package.json
+++ b/package.json
@@ -4,5 +4,18 @@
   "description": "Require babel's ES6 modules from node.",
   "author": "Izaak Schroeder <izaak.schroeder@gmail.com>",
   "license": "CC0-1.0",
-  "repository": "izaakschroeder/interop-require"
+  "repository": "izaakschroeder/interop-require",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.4.1"
+  },
+  "main": "index.js",
+  "files": [
+	"index.js"
+  ],
+  "scripts": {
+    "test": "mocha",
+	"cov": "istanbul cover node_modules/.bin/_mocha"
+  }
 }

--- a/test/fixture/common_export_default.js
+++ b/test/fixture/common_export_default.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.default = function hello() {
+  return 'world';
+}

--- a/test/fixture/common_no_default.js
+++ b/test/fixture/common_no_default.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.hello = function hello() {
+  return 'world';
+}
+

--- a/test/fixture/esmodule_default.js
+++ b/test/fixture/esmodule_default.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class Hello {
+    constructor() {
+    }
+    world() {
+      return 'hello world';
+    }
+}
+exports.default = Hello;

--- a/test/fixture/esmodule_no_default.js
+++ b/test/fixture/esmodule_no_default.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function hello() {
+  return 'world';
+}
+exports.hello = hello;
+;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,43 @@
+'use strict';
+const path = require('path');
+const sut = require('../index.js');
+const expect = require('chai').expect;
+
+function fixture(f) {
+  return path.join(__dirname, './fixture', f);
+}
+
+describe('when request esmodule with default', function() {
+  it('should return module directly', function() {
+    const esmoduleWithDefault = fixture('esmodule_default');
+    const mod = sut(esmoduleWithDefault);
+    expect(mod.name === 'Hello').to.be.ok;
+    expect(new mod().world()).to.eq('hello world');
+  });
+});
+
+describe('when request esmodule without default', function() {
+  it('should return origin module', function() {
+    const esmoduleWithoutDefault = fixture('esmodule_no_default');
+    const mod = sut(esmoduleWithoutDefault);
+    expect(mod.hello.name === 'hello').to.be.ok;
+    expect(mod.hello()).to.eq('world');
+  });
+});
+
+describe('when request common module', function() {
+  it('should return default as property', function() {
+    const commonModuleWithDefault = fixture('common_export_default');
+    const mod = sut(commonModuleWithDefault);
+    expect(mod.default.name === 'hello').to.be.ok;
+    expect(mod.default()).to.eq('world');
+  });
+
+  it('should return module', function() {
+    const commonModuleWithoutDefault = fixture('common_no_default');
+    const mod = sut(commonModuleWithoutDefault);
+    expect(mod.hello.name === 'hello').to.be.ok;
+    expect(mod.hello()).to.eq('world');
+  });
+});
+


### PR DESCRIPTION
require esmodules without default export should return the object.

please refer to 

https://babeljs.io/repl/#?babili=false&evaluate=false&lineWrap=true&presets=es2015%2Creact%2Cstage-0&targets=&browsers=&builtIns=false&debug=false&code=export%20function%20hello()%20%7B%0A%20%20%0A%7D%0A

also add some test.